### PR TITLE
Add user-agent header

### DIFF
--- a/target_elasticsearch/common.py
+++ b/target_elasticsearch/common.py
@@ -17,6 +17,7 @@ SSL_CA_FILE = "ssl_ca_file"
 INDEX_FORMAT = "index_format"
 INDEX_TEMPLATE_FIELDS = "index_schema_fields"
 METADATA_FIELDS = "metadata_fields"
+NAME = "target-elasticsearch"
 
 
 def to_daily(date) -> str:

--- a/target_elasticsearch/sinks.py
+++ b/target_elasticsearch/sinks.py
@@ -236,4 +236,4 @@ class ElasticSink(BatchSink):
         """
         Returns a user agent string for the elasticsearch client
         """
-        return f"meltano-singer-elasticsearch/{PluginBase._get_package_version(NAME)}"
+        return f"meltano-loader-elasticsearch/{PluginBase._get_package_version(NAME)}"

--- a/target_elasticsearch/sinks.py
+++ b/target_elasticsearch/sinks.py
@@ -28,6 +28,7 @@ from target_elasticsearch.common import (
     ELASTIC_MONTHLY_FORMAT,
     ELASTIC_DAILY_FORMAT,
     METADATA_FIELDS,
+    NAME,
     to_daily,
     to_monthly,
     to_yearly,
@@ -197,6 +198,8 @@ class ElasticSink(BatchSink):
         else:
             self.logger.info("using default elastic search connection config")
 
+        config["headers"] = {"user-agent": self._elasticsearch_user_agent()}
+
         return elasticsearch.Elasticsearch(**config)
 
     def write_output(self, records):
@@ -228,3 +231,9 @@ class ElasticSink(BatchSink):
         """
         self.logger.debug(f"Cleaning up sink for {self.stream_name}")
         self.client.close()
+
+    def _elasticsearch_user_agent(self) -> str:
+        """
+        Returns a user agent string for the elasticsearch client
+        """
+        return f"meltano-singer-elasticsearch/{PluginBase._get_package_version(NAME)}"


### PR DESCRIPTION
This adds a `user-agent` header to the Elasticsearch client default client. 

A header can look like: `meltano-loader-elasticsearch/1.2.1`. 